### PR TITLE
Debug prints

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,6 +22,8 @@ mist_SOURCES = \
 	complement.h \
 	computesim.c \
 	computesim.h \
+	debug.c \
+	debug.h \
 	def.h \
 	determinize.c \
 	determinize.h \

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,0 +1,41 @@
+// vim:sw=4:ts=4:cindent
+/*
+   This file is part of mist.
+
+   mist is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   mist is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with mist; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+   Copyright 2014, Pedro Valero
+ */
+
+#include <stdio.h>
+#include <syslog.h>
+#include <stdarg.h>
+#include <string.h>
+
+#include "debug.h"
+
+
+void debug_printf(int line, const char *file, const char *function, char *fmt, ...)
+{
+	char buffer[DEFAULT_BUFF_SIZE];
+	va_list args;
+
+	snprintf(buffer, DEFAULT_BUFF_SIZE, "%s (%s:%d): %s", function, file, line, fmt);
+
+	va_start(args, fmt);
+	vfprintf(stderr, buffer, args);
+	va_end(args);
+}
+

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,0 +1,50 @@
+// vim:sw=4:ts=4:cindent
+/*
+   This file is part of mist.
+
+   mist is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   mist is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with mist; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+   Copyright 2014, Pedro Valero
+ */
+
+#ifndef _DEBUG_H
+#define _DEBUG_H
+
+
+#define DEFAULT_BUFF_SIZE 255
+extern int verbose;
+
+/*
+    These functions provide us with details where the error / event occurred: line, file,
+    function, plus whichever message we wrote explaining the error.
+ */
+void debug_printf(int line, const char *file, const char *function, char *fmt, ...);
+
+/*
+   These macros provide a simpler interface to invoke functions above declared
+   with the correct arguments, and should be preferred.
+ */
+
+/*
+   These macros always expand to actual code.
+ */
+#define PRINTF(...) do {if (verbose >= 1) debug_printf(__LINE__, __FILE__,__PRETTY_FUNCTION__, __VA_ARGS__); } while(0)
+
+
+#define PRINT_IST(X) do {if (verbose >= 2 ) ist_write(X); if (verbose >= 1) ist_stat(X); } while(0)
+
+
+#endif /* _DEBUG_H */
+

--- a/src/mist.c
+++ b/src/mist.c
@@ -37,6 +37,9 @@
 #include "laparser.h"
 #include "ist.h"
 #include "typechecking.h"
+#include "debug.h"
+
+int verbose = 0;
 
 /*To end the executing when timeout event occurs*/
 void timeout_func (int sgn) {
@@ -165,9 +168,7 @@ ISTSharingTree *backward(system, initial_marking, frontier, bounds)
 
 			printf("The new frontier counts :\n");
 			ist_checkup(frontier);
-#ifdef VERBOSE
-			ist_write(frontier);
-#endif
+			PRINT_IST(frontier);
 //			temp=ist_intersection(initial_marking,frontier);
 //			reached = (ist_is_empty(temp) == true ? false : true);
 //			ist_dispose(temp);
@@ -222,9 +223,7 @@ ISTSharingTree *backward(system, initial_marking, frontier, bounds)
 	if (nbr_iteration != 0){
 		puts("The reached symbolic state space is:");
 		ist_stat(reached_elem);
-#ifdef VERBOSE
-		ist_write(reached_elem);
-#endif
+		PRINT_IST(reached_elem);
 	}
 	if (reached == true)
 		ist_print_error_trace(initial_marking,&List,system);
@@ -287,9 +286,7 @@ void backward_basic(system, initial_marking, frontier)
 
 			printf("The new frontier counts :\n");
 			ist_checkup(frontier);
-#ifdef VERBOSE
-			ist_write(frontier);
-#endif
+			PRINT_IST(frontier);
 			temp=ist_intersection(initial_marking,frontier);
 			reached = (ist_is_empty(temp) == true ? false : true);
 			ist_dispose(temp);
@@ -328,9 +325,7 @@ void backward_basic(system, initial_marking, frontier)
 	if (nbr_iteration != 0){
 		puts("The reached symbolic state space is:");
 		ist_stat(reached_elem);
-#ifdef VERBOSE
-		ist_write(reached_elem);
-#endif
+		PRINT_IST(reached_elem);
 	}
 	if (reached == true)
 		ist_print_error_trace(initial_marking,&List,system);
@@ -368,6 +363,7 @@ static void print_help()
 	puts("     --tsi        the algorithm described in TSI");
 	puts("     --eec        the Expand, Enlarge and Check algorithm");
 	puts("     --timeout=T  establish an execution timeout of T seconds");
+	puts("     --verbose=V  establish an verbose level V");
 }
 
 static void head_msg()
@@ -1211,6 +1207,7 @@ static void* mist_cmdline_options_handle(int argc, char *argv[ ], int *timeout, 
 			{"tsi", 0, 0, 't'},
 			{"eec", 0, 0, 'e'},
 			{"timeout", 0, 0, 'o'},
+			{"verbose", 0, 0, 'v'},
 			{0, 0, 0, 0}
 		};
 
@@ -1256,6 +1253,10 @@ static void* mist_cmdline_options_handle(int argc, char *argv[ ], int *timeout, 
 				*timeout = atoi(argv[optind++]);
 				break;
 
+			case 'v':
+				verbose = atoi(argv[optind++]);
+				break;
+
 			default:
 				print_help();
 				err_quit("?? getopt returned character code 0%o ??\n", c);
@@ -1282,7 +1283,7 @@ int main(int argc, char *argv[ ])
 	head_msg();
 	mc=mist_cmdline_options_handle(argc, argv, &timeout, &input_file);
 	assert(mc!=NULL);
-	printf("Timeout established to %d seconds\n", timeout);
+	PRINTF("Timeout established to %d seconds\n", timeout);
 
 	linenumber = 1;
 	tbsymbol_init(&tbsymbol, 4096);


### PR DESCRIPTION
I think that this is a good way to implement these debug prints.

The functions tell us the line and the file who have called them so the debug work becomes easier (which I think is the main purpose of this issue).

If you agree with me then I could try to improve it by defining more debug levels or doing anything we find interesting.

Right now we can compile it as: "make all CFLAGS+=-DDEBUG_LOW=1"  and the timeout message will be printed.
If we compile mist with: "make all" the timeout message will not be shown while executing mist