### PR TITLE
Fixed the problem of the issue #29

### DIFF
--- a/src/proc.c
+++ b/src/proc.c
@@ -414,8 +414,11 @@ void ist_init_system()
 inline void ist_dispose(ST)
 	ISTSharingTree *ST;
 {
-	ST->Next = st_Disposed;
-	st_Disposed = ST;
+
+	if(ST != NULL){
+		ST->Next = st_Disposed;
+		st_Disposed = ST;
+	}
 }
 
 void ist_new(ST)


### PR DESCRIPTION
When I tried to remove the compiling warnings I had to initialize the pointer old frontier to NULL at the beginning of the function backward basic.

For simple examples where there is no iterations of the backward algorithm, this pointer is still null when calling the function 'ist_dispose', which crashes.

I have updated the function 'ist_dispose' to avoid the problem by doing nothing when the argument is a null pointer.