### PR TITLE
Automate build using GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "04:00"
+  open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,6 @@ updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: monthly
     time: "04:00"
   open-pull-requests-limit: 10

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,24 @@
+name: Linux Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - name: build
+      run: ./build_mist.sh
+    - name: Deploy to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@4.1.3
+      with:
+          branch: linux # The branch the action should deploy to.
+          folder: website/ # The folder the action should deploy.
+          clean: true # Automatically remove deleted files from the deploy branch 
+          single-commit: true

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3.0.2
     - name: build
-      run: ./build_mist.sh
+      run: export LDFLAGS='-static-libgcc -static' ; ./build_mist.sh
     - name: Deploy to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@v4.3.3
       with:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -14,9 +14,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3.0.2
     - name: Install packages
-      run: brew install gcc autoconf automake libtool binutils ;
+      run: brew install autoconf automake ;
     - name: build
-      run: export AR='gcc-ar-11'; export NM='gcc-nm-11'; export RANLIB='gcc-ranlib-11'; export CXX='g++-11'; export CC='gcc-11' ;  ./build_mist.sh
+      run: ./build_mist.sh
     - name: rename
       run: mv website/mist_linux.tar.gz website/mist_osx.tar.gz
     - name: Deploy to GitHub Pages

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -1,0 +1,28 @@
+name: OSX Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    
+    runs-on: macos-latest
+    
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - name: Install packages
+      run: brew install gcc autoconf automake libtool binutils ;
+    - name: build
+      run: export AR='gcc-ar-10'; export NM='gcc-nm-10'; export RANLIB='gcc-ranlib-10'; export CXX='g++-10'; export CC='gcc-10' ;  ./build_mist.sh
+    - name: rename
+      run: mv website/mist_linux.tar.gz website/mist_osx.tar.gz
+    - name: Deploy to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@4.1.3
+      with:
+          branch: osx  # The branch the action should deploy to.
+          folder: website/  # The folder the action should deploy.
+          clean: true # Automatically remove deleted files from the deploy branch
+          single-commit: true 

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install packages
       run: brew install gcc autoconf automake libtool binutils ;
     - name: build
-      run: export AR='gcc-ar-10'; export NM='gcc-nm-10'; export RANLIB='gcc-ranlib-10'; export CXX='g++-10'; export CC='gcc-10' ;  ./build_mist.sh
+      run: export AR='gcc-ar-11'; export NM='gcc-nm-11'; export RANLIB='gcc-ranlib-11'; export CXX='g++-11'; export CC='gcc-11' ;  ./build_mist.sh
     - name: rename
       run: mv website/mist_linux.tar.gz website/mist_osx.tar.gz
     - name: Deploy to GitHub Pages

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,47 @@
+name: windows build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    
+    runs-on: windows-latest
+    
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - name: configure and make
+      run:  C:\msys64\usr\bin\bash -lc "PATH+=:/mingw64/bin ; cd /D/a/mist/mist ; ./build_mist.sh && mv website/mist_linux.tar.gz website/mist_windows.tar.gz && cp -r website/ site/ "
+    - name: Upload Artifacts 🔺 # The project is then uploaded as an artifact named 'site'.
+      uses: actions/upload-artifact@v2.2.3
+      with:
+        name: site
+        path: site/
+    
+  deploy:
+    needs: [build] # The second job must depend on the first one to complete before running, and uses ubuntu-latest instead of windows.
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Download Artifacts 🔻 # The built project is downloaded into the 'site' folder.
+        uses: actions/download-artifact@v2.0.9
+        with:
+          name: site
+      - name: move to website
+        run: ls -lah ; mkdir -p windows ; cp mist_windows.tar.gz windows/ ; ls -lah windows/
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.3
+        with:
+          branch: Windows
+          folder: windows/ # The deployment folder should match the name of the artifact. Even though our project builds into the 'build' folder the artifact name of 'site' must be placed here.
+          clean: true # Automatically remove deleted files from the deploy branch
+          single-commit: true 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
     steps:    
     - uses: actions/checkout@v3.0.2
     - name: install packages
-      run:  C:\msys64\usr\bin\bash -lc "PATH+=:/mingw64/bin ; pacman --noconfirm -S autoconf "
+      run:  C:\msys64\usr\bin\bash -lc "PATH+=:/mingw64/bin ; pacman --noconfirm -S autoconf ; pacman --noconfirm -S automake ; pacman --noconfirm -S libtool "
     - name: configure and make
       run:  C:\msys64\usr\bin\bash -lc "PATH+=:/mingw64/bin ; cd /D/a/mist/mist ; ./build_mist.sh && mv website/mist_linux.tar.gz website/mist_windows.tar.gz && cp -r website/ site/ "
     - name: Upload Artifacts 🔺 # The project is then uploaded as an artifact named 'site'.

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
     steps:    
     - uses: actions/checkout@v3.0.2
     - name: install packages
-      run:  C:\msys64\usr\bin\bash -lc "PATH+=:/mingw64/bin ; pacman --noconfirm -S autoconf ; pacman --noconfirm -S automake ; pacman --noconfirm -S libtool "
+      run:  C:\msys64\usr\bin\bash -lc "PATH+=:/mingw64/bin ; pacman --noconfirm -S base-devel ; pacman --noconfirm -S autoconf ; pacman --noconfirm -S automake ; pacman --noconfirm -S libtool "
     - name: configure and make
       run:  C:\msys64\usr\bin\bash -lc "PATH+=:/mingw64/bin ; cd /D/a/mist/mist ; export LDFLAGS='-static-libgcc -static' ; ./build_mist.sh && mv website/mist_linux.tar.gz website/mist_windows.tar.gz && cp -r website/ site/ "
     - name: Upload Artifacts 🔺 # The project is then uploaded as an artifact named 'site'.

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
     steps:    
     - uses: actions/checkout@v3.0.2
     - name: install packages
-      run:  C:\msys64\usr\bin\bash -lc "PATH+=:/mingw64/bin ; pacman --noconfirm -S base-devel "
+      run:  C:\msys64\usr\bin\bash -lc "PATH+=:/mingw64/bin ; pacman --noconfirm -S autoconf "
     - name: configure and make
       run:  C:\msys64\usr\bin\bash -lc "PATH+=:/mingw64/bin ; cd /D/a/mist/mist ; ./build_mist.sh && mv website/mist_linux.tar.gz website/mist_windows.tar.gz && cp -r website/ site/ "
     - name: Upload Artifacts 🔺 # The project is then uploaded as an artifact named 'site'.

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ jobs:
     - name: install packages
       run:  C:\msys64\usr\bin\bash -lc "PATH+=:/mingw64/bin ; pacman --noconfirm -S autoconf ; pacman --noconfirm -S automake ; pacman --noconfirm -S libtool "
     - name: configure and make
-      run:  C:\msys64\usr\bin\bash -lc "PATH+=:/mingw64/bin ; cd /D/a/mist/mist ; ./build_mist.sh && mv website/mist_linux.tar.gz website/mist_windows.tar.gz && cp -r website/ site/ "
+      run:  C:\msys64\usr\bin\bash -lc "PATH+=:/mingw64/bin ; cd /D/a/mist/mist ; export LDFLAGS='-static-libgcc -static' ; ./build_mist.sh && mv website/mist_linux.tar.gz website/mist_windows.tar.gz && cp -r website/ site/ "
     - name: Upload Artifacts 🔺 # The project is then uploaded as an artifact named 'site'.
       uses: actions/upload-artifact@v3.1.0
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
     steps:    
     - uses: actions/checkout@v3.0.2
     - name: install packages
-      run:  C:\msys64\usr\bin\bash -lc "PATH+=:/mingw64/bin ; pacman --noconfirm -S base-devel ; pacman --noconfirm -S autoconf ; pacman --noconfirm -S automake ; pacman --noconfirm -S libtool "
+      run:  C:\msys64\usr\bin\bash -lc "PATH+=:/mingw64/bin ; pacman --noconfirm -S base-devel gcc autoconf automake libtool "
     - name: configure and make
       run:  C:\msys64\usr\bin\bash -lc "PATH+=:/mingw64/bin ; cd /D/a/mist/mist ; export LDFLAGS='-static-libgcc -static' ; ./build_mist.sh && mv website/mist_linux.tar.gz website/mist_windows.tar.gz && cp -r website/ site/ "
     - name: Upload Artifacts 🔺 # The project is then uploaded as an artifact named 'site'.

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,9 +10,11 @@ jobs:
   build:
     
     runs-on: windows-latest
-    
-    steps:
+
+    steps:    
     - uses: actions/checkout@v2.3.4
+    - name: install packages
+      run:  C:\msys64\usr\bin\bash -lc "PATH+=:/mingw64/bin ; pacman --noconfirm -S base-devel "
     - name: configure and make
       run:  C:\msys64\usr\bin\bash -lc "PATH+=:/mingw64/bin ; cd /D/a/mist/mist ; ./build_mist.sh && mv website/mist_linux.tar.gz website/mist_windows.tar.gz && cp -r website/ site/ "
     - name: Upload Artifacts 🔺 # The project is then uploaded as an artifact named 'site'.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ Even though mist has its own input format there it can be translated from other 
 mist also ships with Python scripts to run mist over sets of benchmarks
 and an infrastructure producing bar graphs using [d3js](http://d3js.org/) with runtime and memory consumption information.
 
+## Downloading Mist 
+
+For ease of use, pre-built binaries are available using these links :
+
+* Linux : https://github.com/yanntm/mist/blob/linux/mist_linux.tar.gz?raw=true
+* OSX : https://github.com/yanntm/mist/blob/osx/mist_osx.tar.gz?raw=true
+* Windows : https://github.com/yanntm/mist/blob/windows/mist_windows.tar.gz?raw=true
+
 ## Building mist on Unix
 
 Type `./configure`, then `make`.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ and an infrastructure producing bar graphs using [d3js](http://d3js.org/) with r
 
 For ease of use, pre-built binaries are available using these links :
 
-* Linux : https://github.com/yanntm/mist/blob/linux/mist_linux.tar.gz?raw=true
-* OSX : https://github.com/yanntm/mist/blob/osx/mist_osx.tar.gz?raw=true
-* Windows : https://github.com/yanntm/mist/blob/windows/mist_windows.tar.gz?raw=true
+* [https://github.com/yanntm/mist/blob/linux/mist_linux.tar.gz?raw=true](Linux build)
+* [https://github.com/yanntm/mist/blob/osx/mist_osx.tar.gz?raw=true](Mac OSX build)
+* [https://github.com/yanntm/mist/blob/Windows/mist_windows.tar.gz?raw=true](Windows build)
 
 ## Building mist on Unix
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ and an infrastructure producing bar graphs using [d3js](http://d3js.org/) with r
 
 For ease of use, pre-built binaries are available using these links :
 
-* [https://github.com/yanntm/mist/blob/linux/mist_linux.tar.gz?raw=true](Linux build)
-* [https://github.com/yanntm/mist/blob/osx/mist_osx.tar.gz?raw=true](Mac OSX build)
-* [https://github.com/yanntm/mist/blob/Windows/mist_windows.tar.gz?raw=true](Windows build)
+* [Linux build](https://github.com/yanntm/mist/blob/linux/mist_linux.tar.gz?raw=true)
+* [Mac OSX build](https://github.com/yanntm/mist/blob/osx/mist_osx.tar.gz?raw=true)
+* [Windows build](https://github.com/yanntm/mist/blob/Windows/mist_windows.tar.gz?raw=true)
 
 ## Building mist on Unix
 

--- a/build_mist.sh
+++ b/build_mist.sh
@@ -8,7 +8,7 @@ mkdir -p $INSTALLDIR
 
 autoreconf -vfi
 
-./configure --prefix=$INSTALLDIR LDFLAGS='-static-libgcc -static'
+./configure --prefix=$INSTALLDIR LDFLAGS='-static-libgcc -static' || cat config.log
 
 make install
 

--- a/build_mist.sh
+++ b/build_mist.sh
@@ -8,7 +8,7 @@ mkdir -p $INSTALLDIR
 
 autoreconf -vfi
 
-./configure --prefix=$INSTALLDIR
+./configure --prefix=$INSTALLDIR LDFLAGS='-static-libgcc -static'
 
 make install
 

--- a/build_mist.sh
+++ b/build_mist.sh
@@ -1,0 +1,22 @@
+#! /bin/bash
+
+set -x
+
+export INSTALLDIR=$(pwd)/mist/
+
+mkdir -p $INSTALLDIR
+
+autoreconf -vfi
+
+./configure --prefix=$INSTALLDIR
+
+make install
+
+cp COPYING AUTHORS $INSTALLDIR
+
+tar cvzf mist_linux.tar.gz mist/
+
+mkdir -p website
+
+cp mist_linux.tar.gz website/
+

--- a/build_mist.sh
+++ b/build_mist.sh
@@ -8,7 +8,7 @@ mkdir -p $INSTALLDIR
 
 autoreconf -vfi
 
-./configure --prefix=$INSTALLDIR LDFLAGS='-static-libgcc -static' || cat config.log
+./configure --prefix=$INSTALLDIR || cat config.log
 
 make install
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # Process this file with autoconf to produce a configure script.
-AC_INIT([mist], 1.1)
+AC_INIT([mist],[1.1])
 AC_CONFIG_SRCDIR([src/mist.c])
 AM_INIT_AUTOMAKE
 AC_CONFIG_HEADERS([src/config.h])
@@ -12,8 +12,8 @@ AC_PROG_YACC
 # Checks for libraries.
 
 # Checks for header files.
-AC_STDC_HEADERS
-AC_HAVE_HEADERS(errno.h stdarg.h limits.h string.h sys/types.h getopt.h malloc.h stddef.h stdlib.h sys/time.h unistd.h)
+AC_HEADER_STDC
+AC_CHECK_HEADERS([errno.h stdarg.h limits.h string.h sys/types.h getopt.h malloc.h stddef.h stdlib.h sys/time.h unistd.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
@@ -34,4 +34,5 @@ CFLAGS="-O3 -Wall"
 #AC_CONFIG_FILES()
 AC_SUBST(CFLAGS)
 AC_SUBST(YFLAGS)
-AC_OUTPUT([Makefile src/Makefile])
+AC_CONFIG_FILES([Makefile src/Makefile])
+AC_OUTPUT

--- a/src/abstraction.c
+++ b/src/abstraction.c
@@ -436,7 +436,7 @@ static int ValueInComponent(ISTInterval **V,int *Component,int dim)
 }
 
 //used to compute all the path such that the sum of values appearing in layers given by Component is equal to val
-static ISTNode *PathWithValueInComponent(ISTSharingTree * S, ISTNode * N,ISTLayer *L,int NuLayer,int * Component,int val,int sum)
+static ISTNode *PathWithValueInComponent(ISTSharingTree * S, ISTNode * N,ISTLayer *L,int NuLayer,int * Component,int val,size_t sum)
 {
 	ISTNode *result;
 	ISTSon *s;

--- a/src/basis.c
+++ b/src/basis.c
@@ -175,8 +175,8 @@ static boolean Equal(node1, node2)
             }
         }
     }
-    
-    ist_put_memoization1(node1, node2, (ISTNode*)(Result?1:2)) ; // see above comment.
+    size_t res = (Result?1:2); // patches cast to pointer from integer of different size
+    ist_put_memoization1(node1, node2, (ISTNode*)res) ; // see above comment.
     
     return Result;
 }
@@ -240,8 +240,8 @@ static boolean Included(node1, node2)
             }
         }
     }
-    
-    ist_put_memoization1(node1, node2, (ISTNode*)(Result?1:2)) ; // see above comment.
+    size_t res = (Result?1:2); // patches cast to pointer from integer of different size
+    ist_put_memoization1(node1, node2, (ISTNode*)res) ; // see above comment.
         
 	return Result;
 }

--- a/src/laparser.h
+++ b/src/laparser.h
@@ -35,9 +35,9 @@
 #define EXTERN extern
 #endif
 
-int linenumber;
-int nbr_var;
-T_PTR_tbsymbol tbsymbol;
+EXTERN int linenumber;
+EXTERN int nbr_var;
+EXTERN T_PTR_tbsymbol tbsymbol;
 
 int my_yyparse(T_PTR_tree* tree, char* filename);
 

--- a/src/parser.y
+++ b/src/parser.y
@@ -28,6 +28,9 @@ extern char* yytext;
 T_PTR_tree tmp_tree;
 int yyerror(char *);
 
+int linenumber=0;
+int nbr_var=0;
+T_PTR_tbsymbol tbsymbol=NULL;
 
 %}
 


### PR DESCRIPTION
Hi,

This PR contributes a few GH actions files that allow to build Mist binaries and distribute them.

see e.g. : https://github.com/yanntm/mist/actions

Any time a commit happens, the binaries are rebuilt using CI. I realize the code base is pretty stable but it still might be a comfortable feature to have.

While developing this I also patched a couple of warnings (int to pointer cast, so we use a size_t for the int) and errors (double definition of parser counters, use extern in parser.h + define only once in parser.y) that more recent gcc was upset about.

So the patch contains essentially in .github some new files that handle the CI, the result of a successful build (see Actions tab on Github) is to deploy on branches linux/osx/Windows a tar.gz with the resulting binary for that platform.

If you adopt the PR, you will just need to edit the links I put in the README, e.g.

https://github.com/yanntm/mist/blob/linux/mist_linux.tar.gz?raw=true 

becomes

https://github.com/pierreganty/mist/blob/linux/mist_linux.tar.gz?raw=true

Hope you like it, please ask if you have any questions on how this works but the files are pretty self-explanatory so they should be maintainable even if you did not write them.

Best regards,
Yann Thierry-Mieg